### PR TITLE
Article go top floating button

### DIFF
--- a/app/src/main/java/com/lionheart/presentation/article/ArticleActivity.kt
+++ b/app/src/main/java/com/lionheart/presentation/article/ArticleActivity.kt
@@ -1,5 +1,6 @@
 package com.lionheart.presentation.article
 
+import android.view.View
 import com.lionheart.R
 import com.lionheart.core.binding.BindingActivity
 import com.lionheart.databinding.ActivityArticleBinding
@@ -8,10 +9,10 @@ class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activit
     private lateinit var adaptor: ArticleAdaptor
     override fun constructLayout() {
         setAdaptor()
-        setProgressBar()
     }
 
     override fun addListeners() {
+        listenScroll()
     }
 
     private fun setAdaptor() {
@@ -22,11 +23,26 @@ class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activit
 
     private fun getArticleComponents() = ArticleMocker.mockChapter1()
 
-    private fun setProgressBar() {
+    private fun listenScroll() {
         binding.layoutArticleScroll.setOnScrollChangeListener { v, scrollX, scrollY, oldScrollX, oldScrollY ->
             val maxScroll =
                 binding.layoutArticleScroll.getChildAt(0).height - binding.layoutArticleScroll.height
             binding.progressArticleTop.progress = ((scrollY.toFloat() / maxScroll) * 100).toInt()
+
+            if (scrollY <= oldScrollY) { // on down Scroll
+                binding.fbtnArticleGoTop.visibility = View.VISIBLE
+            } else { // on up Scroll
+                binding.fbtnArticleGoTop.visibility = View.GONE
+            }
+
+            if (scrollY == 0) {
+                binding.fbtnArticleGoTop.visibility = View.GONE
+            }
+        }
+
+        binding.fbtnArticleGoTop.setOnClickListener {
+            binding.layoutArticleScroll.scrollY = 0
+            binding.fbtnArticleGoTop.visibility = View.GONE
         }
     }
 }

--- a/app/src/main/res/drawable/ic_article_go_up.xml
+++ b/app/src/main/res/drawable/ic_article_go_up.xml
@@ -1,0 +1,22 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="19dp"
+    android:viewportWidth="18"
+    android:viewportHeight="19">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M2,11L9,4L16,11"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.5,18C8.5,18.276 8.724,18.5 9,18.5C9.276,18.5 9.5,18.276 9.5,18H8.5ZM9.5,18V4H8.5V18H9.5Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M1,1H17"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -19,39 +19,37 @@
                 android:id="@+id/layout_article_top"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                app:layout_constraintTop_toTopOf="parent"
-                android:background="@color/black">
+                android:background="@color/black"
+                app:layout_constraintTop_toTopOf="parent">
 
                 <ImageView
-                    android:layout_marginVertical="16dp"
                     android:id="@+id/iv_article_top_x"
                     android:layout_width="28dp"
-                    android:layout_height="0dp"
+                    android:layout_height="28dp"
+                    android:layout_marginVertical="16dp"
                     android:layout_marginStart="20dp"
                     android:src="@drawable/ic_article_x"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintBottom_toTopOf="@id/progress_article_top"
-                    app:layout_constraintTop_toTopOf="parent"
-                    />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <com.google.android.material.progressindicator.LinearProgressIndicator
                     android:id="@+id/progress_article_top"
                     android:layout_width="match_parent"
                     android:layout_height="4dp"
-                    app:trackColor="@color/gray_800"
-                    app:layout_constraintTop_toBottomOf="@id/iv_article_top_x"
                     app:indicatorColor="@color/lion_red"
-                    app:layout_constraintBottom_toBottomOf="parent"/>
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/iv_article_top_x"
+                    app:trackColor="@color/gray_800" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-
             <androidx.core.widget.NestedScrollView
-                android:progress="0"
-                android:max="100"
-                android:overScrollMode="never"
                 android:id="@+id/layout_article_scroll"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
+                android:max="100"
+                android:overScrollMode="never"
+                android:progress="0"
                 app:layout_constraintTop_toBottomOf="@id/layout_article_top">
 
                 <LinearLayout
@@ -133,14 +131,28 @@
                         android:id="@+id/rv_article_main"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginTop="32dp"
                         android:overScrollMode="never"
 
+                        android:nestedScrollingEnabled="false"
                         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
                 </LinearLayout>
 
             </androidx.core.widget.NestedScrollView>
 
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fbtn_article_go_top"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="20dp"
+                android:backgroundTint="@color/black"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:shapeAppearance="@null"
+                android:visibility="invisible"
+                app:srcCompat="@drawable/ic_article_go_up" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## *Related issue*
* close #24

## *Description*
- Article View 에서 top 으로 즉시 갈수있는 Floating button 을 추가합니다.
  - 스크롤이 내려갈때는 노출되지 않습니다.
  - 최상단에 있을때는 노출되지 않습니다.
  - 스크롤이 올라가는 경우 노출되어집니다.

## *Screenshot*

https://github.com/gosopt-LionHeart/LionHeart-AOS/assets/88091704/97db5661-e9ff-4157-9de6-fbb6763267a9
